### PR TITLE
fix nestedness of results

### DIFF
--- a/src/defclass-std.lisp
+++ b/src/defclass-std.lisp
@@ -125,17 +125,22 @@
 (defmacro defclass/std (name direct-superclasses direct-slots &rest options)
   "Shortcut macro to the DEFCLASS macro. See README for syntax and usage."
   `(defclass ,name ,direct-superclasses
-     ,@(mapcar (lambda (line)
-                 (let ((prefix (if (or (member :with-prefix line)
-                                       (member :with line)
-                                       *with-prefix*)
-                                   (concatenate 'string (string name) "-")
-                                   ""))
-                       (split-kws-line (split-fusioned-keywords line)))
-                   (check-for-repeated-keywords split-kws-line)
-                   (replace-keywords split-kws-line prefix)))
-               direct-slots)
+     ,(process-slots direct-slots name)
      ,@options))
+
+(defun process-slots (direct-slots classname)
+  (let ((processed (mapcar (lambda (line)
+            (let ((prefix (if (or (member :with-prefix line)
+                                  (member :with line)
+                                  *with-prefix*)
+                              (concatenate 'string (string classname) "-")
+                              ""))
+                  (split-kws-line (split-fusioned-keywords line)))
+              (check-for-repeated-keywords split-kws-line)
+              (replace-keywords split-kws-line prefix)))
+          direct-slots)))
+    ;; un-nest the lists
+    (reduce #'append processed)))
 
 (defmacro class/std (name &body defaulted-slots)
   "Shortcut macro to the DEFCLASS/STD macro."


### PR DESCRIPTION
I'm not an expert with this stuff, but on my machine, defclass/std was expanding into e.g.

```
(defclass foo (stuff)
  ((slot1 ...)) ((slot2 ...)) ...)
```

Which means that `((slot2 ...))` gets treated as a defclass option, and the compiler throws an error. This patch fixes it. It might well not be the right way to fix the problem.
